### PR TITLE
マニピュレータの原点のパラメータを変更

### DIFF
--- a/dynamixel_controller/param/mimi_specification.yaml
+++ b/dynamixel_controller/param/mimi_specification.yaml
@@ -5,5 +5,9 @@ Shoulder_Elbow_Length: 0.22
 Elbow_Wrist_Length: 0.17
 Wrist_Endeffector_Length: 0.17
 
-Origin_Angle: [980, 3040, 2065, 2065, 2150, 1794]
+#Gen2  
+Origin_Angle: [920, 3170, 2065, 2065, 2150, 1794]
+#Gen3
+#Origin_Angle: [1011, 3180, 2065, 2065, 2150, 1794]
+
 Gear_Ratio: [2.1, 2.1, 1, 1, 1, 1]

--- a/dynamixel_controller/src/motor_controller.py
+++ b/dynamixel_controller/src/motor_controller.py
@@ -228,9 +228,14 @@ class ManipulateArm(JointController):
 
         print('m0, m1, m2, m3')
         print(m0, m1, m2, m3)
+        #print(m0, m1)
 	#要検証
         print(map(math.degrees, [m0, m1, m2, m3]))
+        #print(map(math.degrees, [m0, m1]))
         self.motorPub(['m0_shoulder_left_joint', 'm1_shoulder_right_joint', 'm2_elbow_joint', 'm3_wrist_joint'], [m0, m1, m2, m3])
+        #self.motorPub(['m0_shoulder_left_joint', 'm1_shoulder_right_joint'], [m0, m1])
+
+
 
     def armControlService(self, coordinate):
         try:
@@ -276,6 +281,8 @@ class ManipulateArm(JointController):
         wrist_param = 0
         #self.armController([shoulder_param, elbow_param, wrist_param])
         self.armControllerByTopic([shoulder_param, elbow_param, wrist_param])
+        #self.armControllerByTopic([shoulder_param])
+
 
     def carryMode(self):
         shoulder_param = -85


### PR DESCRIPTION
Gen2の「既存のマニピュレータ」と「新マニピュレータ」の原点を合わせたので、dynamixel_controller/param/mimi_specification.yaml の Origin_Angle のパラメータを変えました。